### PR TITLE
Let the bot rebuild the 1.x series

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,8 @@
 azure:
   store_build_artifacts: true
+bot:
+  abi_migration_branches:
+   - 1.x
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
Conda still requires the 1.x series on Windows. Thus it would nice if the bot would also trigger migrations for it.