### PR TITLE
Disable binary relocation to preserve /usr/lib/swift RPATH on macOS launchers

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,16 @@ source:
   sha256: 0c53dd1b692bca901d674a1c2393fa69d22a6463091c51433103a14232cb5e30
 
 build:
-  number: 1
+  number: 2
+  dynamic_linking:
+    # The launcher binaries under menuinst/data/ are standalone .app templates that
+    # get copied verbatim into the shortcuts menuinst creates; they are not linked
+    # into this environment and must not be relocated. Relocation strips the
+    # /usr/lib/swift RPATH from the Swift appkit_launcher, which then fails to load
+    # libswiftCore on Intel macOS (arm64 is unaffected because dyld resolves the OS
+    # Swift runtime from the shared cache regardless). menuinst is pure Python with
+    # no other binaries, so disabling relocation is safe. See conda/menuinst#507.
+    binary_relocation: false
   script:
     env:
       SETUPTOOLS_SCM_PRETEND_VERSION: ${{ version }}


### PR DESCRIPTION
# Disable binary relocation to preserve `/usr/lib/swift` RPATH on macOS launchers

## Checklist

- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (1 → 2)
- [ ] Re-rendered with the latest conda-smithy (will run `conda smithy rerender`)
- [x] Ensured the license file is being packaged

## What this does

Adds `build.dynamic_linking.binary_relocation: false` so the prebuilt launcher binaries
under `menuinst/data/` keep their original RPATHs.

## Why

The `appkit_launcher` binaries are standalone `.app` templates copied verbatim into the
shortcuts menuinst creates; they are not linked into this environment and must not be
relocated. Binary relocation rewrites RPATHs and strips absolute paths pointing outside
the prefix — including the legitimate system path `/usr/lib/swift`.

Without `/usr/lib/swift`, the launcher (which links `libswiftCore`/`libswiftos`/
`libswiftFoundation` non-weak via `@rpath`) cannot load the Swift runtime on **Intel
macOS** and the app fails to start:

```
dyld: Library not loaded: @rpath/libswiftCore.dylib
```

Apple Silicon is unaffected because arm64 dyld resolves the OS Swift runtime from the
shared cache even without the RPATH; only x86_64 needs it explicitly.

menuinst is pure Python with no other binaries to relocate, so disabling relocation is
safe. The launchers are already deleted on Windows/Linux for a related reason ("these
files make the post-build linkage analysis crash").

Full analysis: conda/menuinst#507

## Verification

The repo source binary has `/usr/lib/swift`; the currently published osx-64/osx-arm64
packages have it stripped. Re-adding the RPATH to the shipped launcher resolves the dyld
failure on Intel (macOS 13.7.8), confirming relocation as the cause.
